### PR TITLE
Specify MIT License instead of OtherLicense

### DIFF
--- a/edison-api/EdisonAPI.cabal
+++ b/edison-api/EdisonAPI.cabal
@@ -2,7 +2,7 @@ Build-type:     Simple
 Name:           EdisonAPI
 Cabal-Version:  >= 1.10
 Version:        1.3
-License:        OtherLicense
+License:        MIT
 License-File:   COPYRIGHT
 Author:         Chris Okasaki
 Maintainer:     robdockins AT fastmail DOT fm

--- a/edison-core/EdisonCore.cabal
+++ b/edison-core/EdisonCore.cabal
@@ -2,7 +2,7 @@ Name:           EdisonCore
 Cabal-Version:  >= 1.10
 Build-Type:     Simple
 Version:        1.3.1.1
-License:        OtherLicense
+License:        MIT
 License-File:   COPYRIGHT
 Author:         Chris Okasaki
 Maintainer:     robdockins AT fastmail DOT fm

--- a/test/Edison-test.cabal
+++ b/test/Edison-test.cabal
@@ -2,7 +2,7 @@ Build-type:     Simple
 Name:           Edison-test
 Version:        1.3.1
 Cabal-version:  >= 1.10
-License:        OtherLicense
+License:        MIT
 Maintainer:     robdockins AT fastmail DOT fm
 Synopsis:       Testsuite for Edison
 Category:       Data structures


### PR DESCRIPTION
The current content in COPYRIGHT looks like exactly the MIT License. Since it's a common license and listed in Cabal's documentation[1], I believe it would be better to just write MIT instead of OtherLicense in the License field.

[1] https://www.haskell.org/cabal/release/cabal-latest/doc/API/Cabal/Distribution-License.html