### PR TITLE
Fixed compilation with GHC 7.10

### DIFF
--- a/edison-core/EdisonCore.cabal
+++ b/edison-core/EdisonCore.cabal
@@ -58,6 +58,11 @@ Library
      EdisonAPI == 1.3.*,
      containers,
      array
+
+  if impl(ghc < 8.0)
+    -- Provide/emulate Data.Semigroups` API for pre-GHC-8
+    Build-Depends: semigroups == 0.18.*
+
   Default-Language: Haskell2010
   Default-Extensions:
      MultiParamTypeClasses
@@ -69,4 +74,6 @@ Library
      ScopedTypeVariables
      GeneralizedNewtypeDeriving
      FlexibleContexts
-  Ghc-Options: -funbox-strict-fields -fwarn-incomplete-patterns -Wcompat
+  Ghc-Options: -funbox-strict-fields -fwarn-incomplete-patterns
+  if impl(ghc >= 8.0)
+    Ghc-Options:  -Wcompat


### PR DESCRIPTION
EdisonCore 1.3.2 doesn't compile with GHC 7.10. This PR fix this issue.

Blocking https://github.com/agda/agda/issues/2878.