### PR TITLE
Supported GHC 8.8.1

### DIFF
--- a/edison-api/EdisonAPI.cabal
+++ b/edison-api/EdisonAPI.cabal
@@ -40,6 +40,8 @@ Library
   Build-Depends:
      base == 4.*,
      mtl >= 1.0
+  if impl(ghc < 8.0)
+    build-depends: fail
   Default-Language: Haskell2010
   Default-Extensions:
      MultiParamTypeClasses

--- a/edison-api/src/Data/Edison/Assoc.hs
+++ b/edison-api/src/Data/Edison/Assoc.hs
@@ -71,6 +71,8 @@ module Data.Edison.Assoc (
 
 import Prelude hiding (null,map,lookup,foldr,foldl,foldr1,foldl1,filter)
 
+import qualified Control.Monad.Fail as MF
+
 import Data.Edison.Prelude
 
 import Data.Edison.Seq(Sequence)
@@ -212,7 +214,7 @@ class (Eq k,Functor m) => AssocX m k | m -> k where
   --
   --   This function is /ambiguous/ at finite relation types if the key appears
   --   more than once in the finite relation.  Otherwise, it is /unambiguous/.
-  lookupM        :: (Monad rm) => k -> m a -> rm a
+  lookupM        :: (MF.MonadFail rm) => k -> m a -> rm a
 
   -- | Return all elements bound by the given key in an unspecified order.
   --
@@ -236,7 +238,7 @@ class (Eq k,Functor m) => AssocX m k | m -> k where
   --
   --   This function is /ambiguous/ at finite relation types if the key appears
   --   more than once in the finite relation.  Otherwise, it is /unambiguous/.
-  lookupAndDeleteM :: (Monad rm) => k -> m a -> rm (a, m a)
+  lookupAndDeleteM :: (MF.MonadFail rm) => k -> m a -> rm (a, m a)
 
   -- | Find all elements bound by the given key; return a sequence containing
   --   all such bound elements in an unspecified order and the collection
@@ -395,7 +397,7 @@ class (AssocX m k, Ord k) => OrdAssocX m k | m -> k where
   --
   --   This function is /ambiguous/ at finite relation types if the finite relation
   --   contains more than one minimum key.  Otherwise it is /unambiguous/.
-  minView            :: (Monad rm) => m a -> rm (a, m a)
+  minView            :: (MF.MonadFail rm) => m a -> rm (a, m a)
 
   -- | Find the binding with the minimum key and return its element. Signals
   --   an error if the associative collection is empty.  Which element is chosen
@@ -426,7 +428,7 @@ class (AssocX m k, Ord k) => OrdAssocX m k | m -> k where
   --
   --   This function is /ambiguous/ at finite relation types if the finite relation
   --   contains more than one minimum key.  Otherwise it is /unambiguous/.
-  maxView            :: (Monad rm) => m a -> rm (a, m a)
+  maxView            :: (MF.MonadFail rm) => m a -> rm (a, m a)
 
   -- | Find the binding with the maximum key and return its element.  Signals
   --   an error if the associative collection is empty.  Which element is chosen
@@ -777,7 +779,7 @@ class (Assoc m k, OrdAssocX m k) => OrdAssoc m k | m -> k where
   --   minimum key exists in the relation.  Furthermore, it is /ambiguous/
   --   with respect to the actual key observed unless the @Eq@ instance on
   --   keys corresponds to indistinguisability.
-  minViewWithKey  :: (Monad rm) => m a -> rm ((k, a), m a)
+  minViewWithKey  :: (MF.MonadFail rm) => m a -> rm ((k, a), m a)
 
   -- | Find the binding with the minimum key in an associative collection and
   --   return the key and the element.  Signals an error if the associative
@@ -800,7 +802,7 @@ class (Assoc m k, OrdAssocX m k) => OrdAssoc m k | m -> k where
   --   maximum key exists in the relation.  Furthermore, it is /ambiguous/
   --   with respect to the actual key observed unless the @Eq@ instance on
   --   keys corresponds to indistinguisability.
-  maxViewWithKey  :: (Monad rm) => m a -> rm ((k, a), m a)
+  maxViewWithKey  :: (MF.MonadFail rm) => m a -> rm ((k, a), m a)
 
   -- | Find the binding with the maximum key in an associative collection and
   --   return the key and the element.  Signals an error if the associative

--- a/edison-api/src/Data/Edison/Coll.hs
+++ b/edison-api/src/Data/Edison/Coll.hs
@@ -97,6 +97,7 @@ module Data.Edison.Coll (
 ) where
 
 import Prelude hiding (null,foldr,foldl,foldr1,foldl1,lookup,filter)
+import qualified Control.Monad.Fail as MF
 import Data.Monoid
 
 import Data.Edison.Prelude
@@ -421,7 +422,7 @@ class CollX c a => Coll c a | c -> a where
   --   This function is /ambiguous/ at bag types, when more than one
   --   element equivalent to the given item is in the bag.  Otherwise
   --   it is /unambiguous/.
-  lookupM    :: (Monad m) => a -> c -> m a
+  lookupM    :: (MF.MonadFail m) => a -> c -> m a
 
   -- | Return a sequence containing all elements in the collection equal to
   --   the given element in an unspecified order.
@@ -504,7 +505,7 @@ class (Coll c a, OrdCollX c a) => OrdColl c a | c -> a where
   --
   --   This function is /ambiguous/ at bag types, if more than one minimum
   --   element exists in the bag.  Otherwise, it is /unambiguous/.
-  minView    :: (Monad m) => c -> m (a, c)
+  minView    :: (MF.MonadFail m) => c -> m (a, c)
 
   -- | Return the minimum element in the collection.  If there are multiple
   --   copies of the minimum element, it is unspecified which is chosen.
@@ -523,7 +524,7 @@ class (Coll c a, OrdCollX c a) => OrdColl c a | c -> a where
   --
   --   This function is /ambiguous/ at bag types, if more than one maximum
   --   element exists in the bag.  Otherwise, it is /unambiguous/.
-  maxView    :: (Monad m) => c -> m (a, c)
+  maxView    :: (MF.MonadFail m) => c -> m (a, c)
 
   -- | Return the maximum element in the collection.  If there are multiple
   --   copies of the maximum element, it is unspecified which is chosen.

--- a/edison-api/src/Data/Edison/Seq.hs
+++ b/edison-api/src/Data/Edison/Seq.hs
@@ -58,6 +58,7 @@ import Prelude hiding (concat,reverse,map,concatMap,foldr,foldl,foldr1,foldl1,
                        zip,zip3,zipWith,zipWith3,unzip,unzip3,null)
 
 import Control.Monad
+import qualified Control.Monad.Fail as MF
 import Data.Monoid
 
 import Data.Edison.Prelude
@@ -221,7 +222,7 @@ class (Functor s, MonadPlus s) => Sequence s where
   --   This function is always /unambiguous/.
   --
   --   Default running time: @O( 1 )@
-  lview     :: (Monad m) => s a -> m (a, s a)
+  lview     :: (MF.MonadFail m) => s a -> m (a, s a)
 
   -- | Return the first element of a sequence.
   --   Signals an error if the sequence is empty.
@@ -249,7 +250,7 @@ class (Functor s, MonadPlus s) => Sequence s where
   --   This function is always /unambiguous/.
   --
   --   Default running time: @O( 1 )@
-  lheadM    :: (Monad m) => s a -> m a 
+  lheadM    :: (MF.MonadFail m) => s a -> m a 
 
   -- | Delete the first element of the sequence.
   --   Signals error if sequence is empty.
@@ -277,7 +278,7 @@ class (Functor s, MonadPlus s) => Sequence s where
   --   This function is always /unambiguous/.
   --
   --   Default running time: @O( 1 )@
-  ltailM    :: (Monad m) => s a -> m (s a)
+  ltailM    :: (MF.MonadFail m) => s a -> m (s a)
 
   -- | Separate a sequence into its last (rightmost) element and the
   --   remaining sequence.  Calls 'fail' if the sequence is empty.
@@ -291,7 +292,7 @@ class (Functor s, MonadPlus s) => Sequence s where
   --   This function is always /unambiguous/.
   --
   --   Default running time: @O( n )@
-  rview     :: (Monad m) => s a -> m (a, s a)
+  rview     :: (MF.MonadFail m) => s a -> m (a, s a)
 
   -- | Return the last (rightmost) element of the sequence.
   --   Signals error if sequence is empty.
@@ -319,7 +320,7 @@ class (Functor s, MonadPlus s) => Sequence s where
   --   This function is always /unambiguous/.
   --
   --   Default running time: @O( n )@
-  rheadM    :: (Monad m) => s a -> m a
+  rheadM    :: (MF.MonadFail m) => s a -> m a
 
   -- | Delete the last (rightmost) element of the sequence.
   --   Signals an error if the sequence is empty.
@@ -347,7 +348,7 @@ class (Functor s, MonadPlus s) => Sequence s where
   --   This function is always /unambiguous/.
   --
   --   Default running time: @O( n )@
-  rtailM    :: (Monad m) => s a -> m (s a)
+  rtailM    :: (MF.MonadFail m) => s a -> m (s a)
 
   -- | Returns 'True' if the sequence is empty and 'False' otherwise.
   -- 
@@ -948,7 +949,7 @@ class (Functor s, MonadPlus s) => Sequence s where
   --   This function is always /unambiguous/.
   --
   --   Default running time: @O( i )@
-  lookupM   :: (Monad m) => Int -> s a -> m a
+  lookupM   :: (MF.MonadFail m) => Int -> s a -> m a
 
   -- | Return the element at the given index, or the
   --   default argument if the index is out of bounds.  All indexes are

--- a/edison-api/src/Data/Edison/Seq/ListSeq.hs
+++ b/edison-api/src/Data/Edison/Seq/ListSeq.hs
@@ -41,11 +41,15 @@ import Prelude hiding (concat,reverse,map,concatMap,foldr,foldl,foldr1,foldl1,
                        filter,takeWhile,dropWhile,lookup,take,drop,splitAt,
                        zip,zip3,zipWith,zipWith3,unzip,unzip3,null)
 import qualified Control.Monad.Identity as ID
+import qualified Control.Monad.Fail as MF
 import qualified Prelude
 import Data.Edison.Prelude
 import qualified Data.List
 import Data.Monoid
 import qualified Data.Edison.Seq as S ( Sequence(..) ) 
+
+instance MF.MonadFail ID.Identity where
+  fail = error "Identity(fail)"
 
 -- signatures for exported functions
 moduleName     :: String
@@ -54,16 +58,16 @@ singleton      :: a -> [a]
 lcons          :: a -> [a] -> [a]
 rcons          :: a -> [a] -> [a]
 append         :: [a] -> [a] -> [a]
-lview          :: (Monad rm) => [a] -> rm (a, [a])
+lview          :: (MF.MonadFail rm) => [a] -> rm (a, [a])
 lhead          :: [a] -> a
-lheadM         :: (Monad rm) => [a] -> rm a
+lheadM         :: (MF.MonadFail rm) => [a] -> rm a
 ltail          :: [a] -> [a]
-ltailM         :: (Monad rm) => [a] -> rm [a]
-rview          :: (Monad rm) => [a] -> rm (a, [a])
+ltailM         :: (MF.MonadFail rm) => [a] -> rm [a]
+rview          :: (MF.MonadFail rm) => [a] -> rm (a, [a])
 rhead          :: [a] -> a
-rheadM         :: (Monad rm) => [a] -> rm a
+rheadM         :: (MF.MonadFail rm) => [a] -> rm a
 rtail          :: [a] -> [a]
-rtailM         :: (Monad rm) => [a] -> rm [a]
+rtailM         :: (MF.MonadFail rm) => [a] -> rm [a]
 null           :: [a] -> Bool
 size           :: [a] -> Int
 concat         :: [[a]] -> [a]
@@ -92,7 +96,7 @@ reduce1'       :: (a -> a -> a) -> [a] -> a
 copy           :: Int -> a -> [a]
 inBounds       :: Int -> [a] -> Bool
 lookup         :: Int -> [a] -> a
-lookupM        :: (Monad m) => Int -> [a] -> m a
+lookupM        :: (MF.MonadFail m) => Int -> [a] -> m a
 lookupWithDefault :: a -> Int -> [a] -> a
 update         :: Int -> a -> [a] -> [a]
 adjust         :: (a -> a) -> Int -> [a] -> [a]

--- a/edison-core/EdisonCore.cabal
+++ b/edison-core/EdisonCore.cabal
@@ -62,8 +62,10 @@ Library
      array
 
   if impl(ghc < 8.0)
-    -- Provide/emulate Data.Semigroups` API for pre-GHC-8
-    Build-Depends: semigroups == 0.18.*
+    Build-Depends:
+      fail,
+      -- Provide/emulate Data.Semigroups` API for pre-GHC-8
+      semigroups == 0.18.*
 
   Default-Language: Haskell2010
   Default-Extensions:

--- a/edison-core/src/Data/Edison/Assoc/AssocList.hs
+++ b/edison-core/src/Data/Edison/Assoc/AssocList.hs
@@ -58,6 +58,7 @@ import Prelude hiding (null,map,lookup,foldr,foldl,foldr1,foldl1,filter)
 import qualified Prelude
 import Data.Monoid
 import Data.Semigroup as SG
+import qualified Control.Monad.Fail as MF
 import Control.Monad.Identity
 import qualified Data.Edison.Assoc as A
 import qualified Data.Edison.Seq as S
@@ -82,10 +83,10 @@ size          :: Eq k => FM k a -> Int
 member        :: Eq k => k -> FM k a -> Bool
 count         :: Eq k => k -> FM k a -> Int
 lookup        :: Eq k => k -> FM k a -> a
-lookupM       :: (Eq k, Monad rm) => k -> FM k a -> rm a
+lookupM       :: (Eq k, MF.MonadFail rm) => k -> FM k a -> rm a
 lookupAll     :: (Eq k,S.Sequence seq) => k -> FM k a -> seq a
 lookupAndDelete    :: Eq k => k -> FM k a -> (a,FM k a)
-lookupAndDeleteM   :: (Eq k,Monad rm)   => k -> FM k a -> rm (a,FM k a)
+lookupAndDeleteM   :: (Eq k, MF.MonadFail rm)   => k -> FM k a -> rm (a,FM k a)
 lookupAndDeleteAll :: (Eq k,S.Sequence seq) => k -> FM k a -> (seq a,FM k a)
 lookupWithDefault  :: Eq k => a -> k -> FM k a -> a
 adjust             :: Eq k => (a -> a) -> k -> FM k a -> FM k a
@@ -143,11 +144,11 @@ unionSeqWithKey  :: (Eq k,S.Sequence seq) =>
                         (k -> a -> a -> a) -> seq (FM k a) -> FM k a
 intersectionWithKey :: Eq k => (k -> a -> b -> c) -> FM k a -> FM k b -> FM k c
 
-minView          :: (Ord k,Monad m) => FM k a -> m (a,FM k a)
+minView          :: (Ord k, MF.MonadFail m) => FM k a -> m (a,FM k a)
 minElem          :: Ord k => FM k a -> a
 deleteMin        :: Ord k => FM k a -> FM k a
 unsafeInsertMin  :: Ord k => k -> a -> FM k a -> FM k a
-maxView          :: (Ord k,Monad m) => FM k a -> m (a,FM k a)
+maxView          :: (Ord k, MF.MonadFail m) => FM k a -> m (a,FM k a)
 maxElem          :: Ord k => FM k a -> a
 deleteMax        :: Ord k => FM k a -> FM k a
 unsafeInsertMax  :: Ord k => k -> a -> FM k a -> FM k a
@@ -169,9 +170,9 @@ partitionLT_GE   :: Ord k => k -> FM k a -> (FM k a,FM k a)
 partitionLE_GT   :: Ord k => k -> FM k a -> (FM k a,FM k a)
 partitionLT_GT   :: Ord k => k -> FM k a -> (FM k a,FM k a)
 
-minViewWithKey    :: (Ord k,Monad m) => FM k a -> m ((k, a), FM k a)
+minViewWithKey    :: (Ord k, MF.MonadFail m) => FM k a -> m ((k, a), FM k a)
 minElemWithKey    :: Ord k => FM k a -> (k,a)
-maxViewWithKey    :: (Ord k,Monad m) => FM k a -> m ((k, a), FM k a)
+maxViewWithKey    :: (Ord k, MF.MonadFail m) => FM k a -> m ((k, a), FM k a)
 maxElemWithKey    :: Ord k => FM k a -> (k,a)
 foldrWithKey      :: Ord k => (k -> a -> b -> b) -> b -> FM k a -> b
 foldlWithKey      :: Ord k => (b -> k -> a -> b) -> b -> FM k a -> b

--- a/edison-core/src/Data/Edison/Assoc/Defaults.hs
+++ b/edison-core/src/Data/Edison/Assoc/Defaults.hs
@@ -15,6 +15,8 @@ module Data.Edison.Assoc.Defaults where
 
 import Prelude hiding (null,map,lookup,foldr,foldl,foldr1,foldl1,filter)
 
+import qualified Control.Monad.Fail as MF
+
 import Data.Edison.Assoc
 import qualified Data.Edison.Seq as S
 import qualified Data.Edison.Seq.ListSeq as L
@@ -190,7 +192,7 @@ lookupAndDeleteDefault k m =
      Nothing -> error (instanceName m ++ ".lookupAndDelete: lookup failed")
      Just x  -> (x, delete k m)
 
-lookupAndDeleteMDefault :: (Monad rm, AssocX m k) => k -> m a -> rm (a, m a)
+lookupAndDeleteMDefault :: (MF.MonadFail rm, AssocX m k) => k -> m a -> rm (a, m a)
 lookupAndDeleteMDefault k m =
   case lookupM k m of
      Nothing -> fail (instanceName m ++ ".lookupAndDelete: lookup failed")

--- a/edison-core/src/Data/Edison/Assoc/PatriciaLoMap.hs
+++ b/edison-core/src/Data/Edison/Assoc/PatriciaLoMap.hs
@@ -55,6 +55,7 @@ module Data.Edison.Assoc.PatriciaLoMap (
 
 import Prelude hiding (null,map,lookup,foldr,foldl,foldr1,foldl1,filter)
 import qualified Prelude
+import qualified Control.Monad.Fail as MF
 import Control.Monad.Identity (runIdentity)
 import Data.Monoid
 import Data.Semigroup as SG
@@ -212,7 +213,7 @@ member k (B _ m t0 t1) = if zeroBit k m then member k t0 else member k t1
 lookup :: Int -> FM a -> a
 lookup k m = runIdentity (lookupM k m)
 
-lookupM :: (Monad rm) => Int -> FM a -> rm a
+lookupM :: (MF.MonadFail rm) => Int -> FM a -> rm a
 lookupM _ E = fail "PatriciaLoMap.lookup: lookup failed"
 lookupM k (L j x)
   | j == k    = return x
@@ -233,7 +234,7 @@ lookupAndDelete        = doLookupAndDelete
                            (error "PatriciaLoMap.lookupAndDelete: lookup failed")
                            (,)
 
-lookupAndDeleteM :: Monad m => Int -> FM a -> m (a, FM a)
+lookupAndDeleteM :: MF.MonadFail m => Int -> FM a -> m (a, FM a)
 lookupAndDeleteM       = doLookupAndDelete
                            (fail "PatriciaLoMap.lookupAndDelete: lookup failed")
                            (\x m -> return (x,m))
@@ -583,25 +584,25 @@ ordListFM_rev (B _ _ t0 t1) = merge (ordListFM_rev t0) (ordListFM_rev t1)
             GT -> x : merge xs (y:ys)
             EQ -> error "PatriciaLoMap: bug in ordListFM_rev"
 
-minView :: Monad m => FM a -> m (a, FM a)
+minView :: MF.MonadFail m => FM a -> m (a, FM a)
 minView fm =
    case ordListFM fm of
      [] -> fail $ moduleName++".minView: empty map"
      ((k,x):_) -> return (x,delete k fm)
 
-minViewWithKey :: Monad m => FM a -> m ((Int, a), FM a)
+minViewWithKey :: MF.MonadFail m => FM a -> m ((Int, a), FM a)
 minViewWithKey fm =
    case ordListFM fm of
      [] -> fail $ moduleName++".minViewWithKey: empty map"
      ((k,x):_) -> return ((k,x),delete k fm)
 
-maxView :: Monad m => FM a -> m (a, FM a)
+maxView :: MF.MonadFail m => FM a -> m (a, FM a)
 maxView fm =
   case ordListFM_rev fm of
      [] -> fail $ moduleName++".maxView: empty map"
      ((k,x):_) -> return (x,delete k fm)
 
-maxViewWithKey :: Monad m => FM a -> m ((Int, a), FM a)
+maxViewWithKey :: MF.MonadFail m => FM a -> m ((Int, a), FM a)
 maxViewWithKey fm =
    case ordListFM_rev fm of
      [] -> fail $ moduleName++".maxViewWithKey: empty map"

--- a/edison-core/src/Data/Edison/Assoc/StandardMap.hs
+++ b/edison-core/src/Data/Edison/Assoc/StandardMap.hs
@@ -51,6 +51,7 @@ module Data.Edison.Assoc.StandardMap (
 
 import Prelude hiding (null,map,lookup,foldr,foldl,foldr1,foldl1,filter)
 import qualified Prelude
+import qualified Control.Monad.Fail as MF
 import qualified Data.Edison.Assoc as A
 import qualified Data.Edison.Seq as S
 import qualified Data.Edison.Seq.ListSeq as L
@@ -81,10 +82,10 @@ member            :: Ord k => k -> FM k a -> Bool
 count             :: Ord k => k -> FM k a -> Int
 lookup            :: Ord k => k -> FM k a -> a
 lookupAll         :: (Ord k,S.Sequence seq) => k -> FM k a -> seq a
-lookupM           :: (Ord k,Monad m) => k -> FM k a -> m a
+lookupM           :: (Ord k, MF.MonadFail m) => k -> FM k a -> m a
 lookupWithDefault :: Ord k => a -> k -> FM k a -> a
 lookupAndDelete   :: Ord k => k -> FM k a -> (a, FM k a)
-lookupAndDeleteM  :: (Ord k,Monad m) => k -> FM k a -> m (a, FM k a)
+lookupAndDeleteM  :: (Ord k, MF.MonadFail m) => k -> FM k a -> m (a, FM k a)
 lookupAndDeleteAll :: (Ord k,S.Sequence seq) => k -> FM k a -> (seq a,FM k a)
 adjust            :: Ord k => (a->a) -> k -> FM k a -> FM k a
 adjustAll         :: Ord k => (a->a) -> k -> FM k a -> FM k a
@@ -103,11 +104,11 @@ filter            :: Ord k => (a -> Bool) -> FM k a -> FM k a
 partition         :: Ord k => (a -> Bool) -> FM k a -> (FM k a,FM k a)
 elements          :: (Ord k,S.Sequence seq) => FM k a -> seq a
 
-minView           :: (Ord k,Monad m) => FM k a -> m (a, FM k a)
+minView           :: (Ord k, MF.MonadFail m) => FM k a -> m (a, FM k a)
 minElem           :: Ord k => FM k a -> a
 deleteMin         :: Ord k => FM k a -> FM k a
 unsafeInsertMin   :: Ord k => k -> a -> FM k a -> FM k a
-maxView           :: (Ord k,Monad m) => FM k a -> m (a, FM k a)
+maxView           :: (Ord k, MF.MonadFail m) => FM k a -> m (a, FM k a)
 maxElem           :: Ord k => FM k a -> a
 deleteMax         :: Ord k => FM k a -> FM k a
 unsafeInsertMax   :: Ord k => k -> a -> FM k a -> FM k a
@@ -165,9 +166,9 @@ foldWithKey'      :: Ord k => (k -> a -> b -> b) -> b -> FM k a -> b
 filterWithKey     :: Ord k => (k -> a -> Bool) -> FM k a -> FM k a
 partitionWithKey  :: Ord k => (k -> a -> Bool) -> FM k a -> (FM k a,FM k a)
 
-minViewWithKey    :: (Ord k,Monad m) => FM k a -> m ((k, a), FM k a)
+minViewWithKey    :: (Ord k, MF.MonadFail m) => FM k a -> m ((k, a), FM k a)
 minElemWithKey    :: Ord k => FM k a -> (k,a)
-maxViewWithKey    :: (Ord k,Monad m) => FM k a -> m ((k, a), FM k a)
+maxViewWithKey    :: (Ord k, MF.MonadFail m) => FM k a -> m ((k, a), FM k a)
 maxElemWithKey    :: Ord k => FM k a -> (k,a)
 foldrWithKey      :: (k -> a -> b -> b) -> b -> FM k a -> b
 foldlWithKey      :: (b -> k -> a -> b) -> b -> FM k a -> b

--- a/edison-core/src/Data/Edison/Assoc/TernaryTrie.hs
+++ b/edison-core/src/Data/Edison/Assoc/TernaryTrie.hs
@@ -57,6 +57,7 @@ import qualified Prelude
 import qualified Data.Edison.Assoc as A
 import qualified Data.Edison.Seq as S
 import qualified Data.List as L
+import qualified Control.Monad.Fail as MF
 import Control.Monad.Identity
 import Data.Monoid
 import Data.Semigroup as SG
@@ -83,10 +84,10 @@ size          :: Ord k => FM k a -> Int
 member        :: Ord k => [k] -> FM k a -> Bool
 count         :: Ord k => [k] -> FM k a -> Int
 lookup        :: Ord k => [k] -> FM k a -> a
-lookupM       :: (Ord k, Monad rm) => [k] -> FM k a -> rm a
+lookupM       :: (Ord k, MF.MonadFail rm) => [k] -> FM k a -> rm a
 lookupAll     :: (Ord k,S.Sequence seq) => [k] -> FM k a -> seq a
 lookupAndDelete    :: Ord k => [k] -> FM k a -> (a, FM k a)
-lookupAndDeleteM   :: (Ord k, Monad rm) => [k] -> FM k a -> rm (a, FM k a)
+lookupAndDeleteM   :: (Ord k, MF.MonadFail rm) => [k] -> FM k a -> rm (a, FM k a)
 lookupAndDeleteAll :: (Ord k, S.Sequence seq) => [k] -> FM k a -> (seq a,FM k a)
 lookupWithDefault  :: Ord k => a -> [k] -> FM k a -> a
 adjust        :: Ord k => (a -> a) -> [k] -> FM k a -> FM k a
@@ -854,18 +855,18 @@ intersectionWithKey f
 
 -- OrdAssocX
 
-minViewFMB :: Monad m => FMB k a -> (FMB k a -> FM k a) -> m (a, FM k a)
+minViewFMB :: MF.MonadFail m => FMB k a -> (FMB k a -> FM k a) -> m (a, FM k a)
 minViewFMB E _ = fail $ moduleName++".minView: empty map"
 minViewFMB (I i k (Just v) E m r)        f = return (v, f (I i k Nothing E m r))
 minViewFMB (I _ _ Nothing  E (FMB' E) _) _ = error $ moduleName++".minView: bug!"
 minViewFMB (I _ k Nothing  E (FMB' m) r) f = minViewFMB m (\m' -> f (mkVBalancedFMB k Nothing E (FMB' m') r))
 minViewFMB (I _ k mv l m r)              f = minViewFMB l (\l' -> f (mkVBalancedFMB k mv l' m r))
 
-minView :: Monad m => FM k a -> m (a,FM k a)
+minView :: MF.MonadFail m => FM k a -> m (a,FM k a)
 minView (FM (Just v) fmb) = return (v, FM Nothing fmb)
 minView (FM Nothing fmb)  = minViewFMB fmb (FM Nothing)
 
-minViewWithKeyFMB :: Monad m => FMB k a -> ([k] -> [k]) -> (FMB k a -> FM k a) -> m (([k],a),FM k a)
+minViewWithKeyFMB :: MF.MonadFail m => FMB k a -> ([k] -> [k]) -> (FMB k a -> FM k a) -> m (([k],a),FM k a)
 minViewWithKeyFMB E _ _ = fail $ moduleName++".minView: empty map"
 minViewWithKeyFMB (I i k (Just v) E m r)        kf f = return ((kf [k],v),f (I i k Nothing E m r))
 minViewWithKeyFMB (I _ _ Nothing  E (FMB' E) _) _ _ = error $ moduleName++".minViewWithKey: bug!"
@@ -874,7 +875,7 @@ minViewWithKeyFMB (I _ k Nothing  E (FMB' m) r) kf f = minViewWithKeyFMB m (kf .
 minViewWithKeyFMB (I _ k mv l m r)              kf f = minViewWithKeyFMB l kf
                                                         (\l' -> f (mkVBalancedFMB k mv l' m r))
 
-minViewWithKey :: Monad m => FM k a -> m (([k],a),FM k a)
+minViewWithKey :: MF.MonadFail m => FM k a -> m (([k],a),FM k a)
 minViewWithKey (FM (Just v) fmb) = return (([],v),FM Nothing fmb)
 minViewWithKey (FM Nothing fmb)  = minViewWithKeyFMB fmb id (FM Nothing)
 
@@ -906,7 +907,7 @@ deleteMin = deleteMinUsingMinView
 unsafeInsertMin :: Ord k => [k] -> a -> FM k a -> FM k a
 unsafeInsertMin = insert
 
-maxViewFMB :: Monad m => FMB k a -> (FMB k a -> FM k a) -> m (a, FM k a)
+maxViewFMB :: MF.MonadFail m => FMB k a -> (FMB k a -> FM k a) -> m (a, FM k a)
 maxViewFMB (I _ _ (Just v) l (FMB' E) E) f = return (v, f l)
 --maxViewFMB (I i k (Just v) l (FMB' E) E) f = return (v, f (I i k Nothing l (FMB' E) E))
 maxViewFMB (I _ _ Nothing  _ (FMB' E) E) _ = error $ moduleName++".maxView: bug!"
@@ -914,7 +915,7 @@ maxViewFMB (I i k mv l (FMB' m) E)       f = maxViewFMB m (\m' -> f (I i k mv l 
 maxViewFMB (I _ k mv l m r)              f = maxViewFMB r (\r' -> f (mkVBalancedFMB k mv l m r'))
 maxViewFMB E                             _ = error $ moduleName++".maxView: bug!"
 
-maxView :: Monad m => FM k a -> m (a, FM k a)
+maxView :: MF.MonadFail m => FM k a -> m (a, FM k a)
 maxView (FM Nothing E)  = fail $ moduleName++".maxView: empty map"
 maxView (FM (Just v) E) = return (v,FM Nothing E)
 maxView (FM mv fmb)     = maxViewFMB fmb (FM mv)
@@ -930,7 +931,7 @@ maxViewWithKeyFMB (I _ k mv l m r)              kf f = maxViewWithKeyFMB r kf
 maxViewWithKeyFMB E                             _ _ = error $ moduleName++".maxViewWithKey: bug!"
 
 
-maxViewWithKey :: Monad m => FM k a -> m (([k],a), FM k a)
+maxViewWithKey :: MF.MonadFail m => FM k a -> m (([k],a), FM k a)
 maxViewWithKey (FM Nothing E)  = fail $ moduleName++".maxViewWithKey: empty map"
 maxViewWithKey (FM (Just v) E) = return (([],v),FM Nothing E)
 maxViewWithKey (FM mv fmb)     = maxViewWithKeyFMB fmb id (FM mv)

--- a/edison-core/src/Data/Edison/Coll/Defaults.hs
+++ b/edison-core/src/Data/Edison/Coll/Defaults.hs
@@ -14,6 +14,7 @@
 module Data.Edison.Coll.Defaults where
 
 import Prelude hiding (null,foldr,foldl,foldr1,foldl1,lookup,filter)
+import qualified Control.Monad.Fail as MF
 import Control.Monad.Identity
 
 import Data.Edison.Coll
@@ -81,7 +82,7 @@ disjointUsingToOrdList xs ys = disj (toOrdList xs) (toOrdList ys)
         disj _ _ = True
 
 intersectWitnessUsingToOrdList ::
-        (OrdColl c a, Monad m) => c -> c -> m (a,a)
+        (OrdColl c a, MF.MonadFail m) => c -> c -> m (a,a)
 intersectWitnessUsingToOrdList as bs = witness (toOrdList as) (toOrdList bs)
   where witness a@(x:xs) b@(y:ys) =
           case compare x y of
@@ -100,7 +101,7 @@ lookupUsingLookupAll x ys =
     (y:_) -> y
     [] -> error $ instanceName ys ++ ".lookup: lookup failed"
 
-lookupMUsingLookupAll :: (Coll c a, Monad m) => a -> c -> m a
+lookupMUsingLookupAll :: (Coll c a, MF.MonadFail m) => a -> c -> m a
 lookupMUsingLookupAll x ys =
   case lookupAll x ys of
     (y:_) -> return y

--- a/edison-core/src/Data/Edison/Coll/EnumSet.hs
+++ b/edison-core/src/Data/Edison/Coll/EnumSet.hs
@@ -157,6 +157,7 @@ module Data.Edison.Coll.EnumSet (
 
 import qualified Prelude
 import Prelude hiding (filter,foldl,foldr,null,map,lookup,foldl1,foldr1)
+import qualified Control.Monad.Fail as MF
 import qualified Data.Bits as Bits
 import Data.Bits hiding (complement)
 import Data.Word
@@ -251,7 +252,7 @@ count = countUsingMember
 lookup :: (Eq a, Enum a) => a -> Set a -> a
 lookup = lookupUsingLookupAll
 
-lookupM :: (Eq a, Enum a, Monad m) => a -> Set a -> m a
+lookupM :: (Eq a, Enum a, MF.MonadFail m) => a -> Set a -> m a
 lookupM x s
    | member x s = return x
    | otherwise  = fail (moduleName++".lookupM: lookup failed")
@@ -340,12 +341,12 @@ deleteMax (Set w)
    | w == 0    = empty
    | otherwise = Set $ clearBit w $ msb w
 
-minView :: (Enum a, Monad m) => Set a -> m (a, Set a)
+minView :: (Enum a, MF.MonadFail m) => Set a -> m (a, Set a)
 minView (Set w)
    | w == 0    = fail (moduleName++".minView: empty set")
    | otherwise = let i = lsb w in return (toEnum i,Set $ clearBit w i)
 
-maxView :: (Enum a, Monad m) => Set a -> m (a, Set a)
+maxView :: (Enum a, MF.MonadFail m) => Set a -> m (a, Set a)
 maxView (Set w)
    | w == 0    = fail (moduleName++".maxView: empty set")
    | otherwise = let i = msb w in return (toEnum i, Set $ clearBit w i)

--- a/edison-core/src/Data/Edison/Coll/LazyPairingHeap.hs
+++ b/edison-core/src/Data/Edison/Coll/LazyPairingHeap.hs
@@ -49,6 +49,7 @@ import Data.List (sort)
 import Data.Monoid
 import Data.Semigroup as SG
 import Control.Monad
+import qualified Control.Monad.Fail as MF
 import Test.QuickCheck
 
 moduleName :: String
@@ -359,7 +360,7 @@ lookupAll y h = look h S.empty
             EQ -> S.lcons x $ look i $ look xs rest
             GT -> rest
 
-minView :: (Ord a, Monad m) => Heap a -> m (a, Heap a)
+minView :: (Ord a, MF.MonadFail m) => Heap a -> m (a, Heap a)
 minView E = fail "LazyPairingHeap.minView: empty heap"
 minView (H1 x xs) = return (x,xs)
 minView (H2 x h xs) = return (x,union h xs)
@@ -369,7 +370,7 @@ minElem E = error "LazyPairingHeap.minElem: empty heap"
 minElem (H1 x _) = x
 minElem (H2 x _ _) = x
 
-maxView :: (Ord a, Monad m) => Heap a -> m (a, Heap a)
+maxView :: (Ord a, MF.MonadFail m) => Heap a -> m (a, Heap a)
 maxView E = fail "LazyPairingHeap.maxView: empty heap"
 maxView xs = return (y,xs')
   where (xs', y) = maxView' xs
@@ -474,7 +475,7 @@ deleteMax = deleteMaxUsingMaxView
 lookup :: Ord a => a -> Heap a -> a
 lookup = lookupUsingLookupAll
 
-lookupM :: (Ord a, Monad m) => a -> Heap a -> m a
+lookupM :: (Ord a, MF.MonadFail m) => a -> Heap a -> m a
 lookupM = lookupMUsingLookupAll
 
 lookupWithDefault :: Ord a => a -> a -> Heap a -> a

--- a/edison-core/src/Data/Edison/Coll/LeftistHeap.hs
+++ b/edison-core/src/Data/Edison/Coll/LeftistHeap.hs
@@ -47,6 +47,7 @@ import Data.Edison.Coll.Defaults
 import Data.Monoid
 import Data.Semigroup as SG
 import Control.Monad
+import qualified Control.Monad.Fail as MF
 import Test.QuickCheck
 
 moduleName :: String
@@ -173,7 +174,7 @@ toSeq h = tol h S.empty
   where tol E rest = rest
         tol (L _ x a b) rest = S.lcons x (tol b (tol a rest))
 
-lookupM :: (Ord a, Monad m) => a -> Heap a -> m a
+lookupM :: (Ord a, MF.MonadFail m) => a -> Heap a -> m a
 lookupM _ E = fail "LeftistHeap.lookupM: XXX"
 lookupM x (L _ y a b) =
   case compare x y of
@@ -299,7 +300,7 @@ partitionLT_GT y h = (h', C.unionList hs)
                       (b', hs'') = collect b hs'
                   in (node x a' b', hs'')
 
-minView :: (Ord a, Monad m) => Heap a -> m (a, Heap a)
+minView :: (Ord a, MF.MonadFail m) => Heap a -> m (a, Heap a)
 minView E = fail "LeftistHeap.minView: empty collection"
 minView (L _ x a b) = return (x, union a b)
 
@@ -307,7 +308,7 @@ minElem :: Ord a => Heap a -> a
 minElem E = error "LeftistHeap.minElem: empty collection"
 minElem (L _ x _ _) = x
 
-maxView :: (Ord a, Monad m) => Heap a -> m (a, Heap a)
+maxView :: (Ord a, MF.MonadFail m) => Heap a -> m (a, Heap a)
 maxView E = fail "LeftistHeap.maxView: empty collection"
 maxView (L _ x E _) = return (x, E)
 maxView (L _ x a E) = return (y, L 1 x a' E)

--- a/edison-core/src/Data/Edison/Coll/MinHeap.hs
+++ b/edison-core/src/Data/Edison/Coll/MinHeap.hs
@@ -46,6 +46,7 @@ import Data.Edison.Seq.Defaults (tokenMatch,maybeParens)
 import Data.Monoid
 import qualified Data.Semigroup as SG
 import Control.Monad
+import qualified Control.Monad.Fail as MF
 import Test.QuickCheck
 
 data Min h a = E | M a h  deriving (Eq)
@@ -75,7 +76,7 @@ strict    :: (C.CollX h a,Ord a) => Min h a -> Min h a
 
 toSeq     :: (C.Coll h a,S.Sequence s) => Min h a -> s a
 lookup    :: (C.Coll h a,Ord a) => a -> Min h a -> a
-lookupM   :: (C.Coll h a,Ord a,Monad m) => a -> Min h a -> m a
+lookupM   :: (C.Coll h a, Ord a, MF.MonadFail m) => a -> Min h a -> m a
 lookupAll :: (C.Coll h a,Ord a,S.Sequence s) => a -> Min h a -> s a
 lookupWithDefault :: (C.Coll h a,Ord a) => a -> a -> Min h a -> a
 fold      :: (C.Coll h a) => (a -> b -> b) -> b -> Min h a -> b
@@ -100,9 +101,9 @@ partitionLT_GE :: (C.OrdColl h a,Ord a) => a -> Min h a -> (Min h a, Min h a)
 partitionLE_GT :: (C.OrdColl h a,Ord a) => a -> Min h a -> (Min h a, Min h a)
 partitionLT_GT :: (C.OrdColl h a,Ord a) => a -> Min h a -> (Min h a, Min h a)
 
-minView :: (C.OrdColl h a,Ord a,Monad m) => Min h a -> m (a, Min h a)
+minView :: (C.OrdColl h a, Ord a, MF.MonadFail m) => Min h a -> m (a, Min h a)
 minElem :: (C.OrdColl h a,Ord a) => Min h a -> a
-maxView :: (C.OrdColl h a,Ord a,Monad m) => Min h a -> m (a, Min h a)
+maxView :: (C.OrdColl h a, Ord a, MF.MonadFail m) => Min h a -> m (a, Min h a)
 maxElem :: (C.OrdColl h a,Ord a) => Min h a -> a
 foldr :: (C.OrdColl h a,Ord a) => (a -> b -> b) -> b -> Min h a -> b
 foldl :: (C.OrdColl h a,Ord a) => (b -> a -> b) -> b -> Min h a -> b

--- a/edison-core/src/Data/Edison/Coll/SkewHeap.hs
+++ b/edison-core/src/Data/Edison/Coll/SkewHeap.hs
@@ -47,6 +47,7 @@ import Data.Edison.Coll.Defaults
 import Data.Monoid
 import Data.Semigroup as SG
 import Control.Monad
+import qualified Control.Monad.Fail as MF
 
 import Test.QuickCheck
 
@@ -142,7 +143,7 @@ toSeq h = tol h S.empty
   where tol E rest = rest
         tol (T x a b) rest = S.lcons x (tol b (tol a rest))
 
-lookupM :: (Ord a, Monad m) => a -> Heap a -> m a
+lookupM :: (Ord a, MF.MonadFail m) => a -> Heap a -> m a
 lookupM _ E = fail "SkewHeap.lookupM: XXX"
 lookupM x (T y a b) =
   case compare x y of
@@ -267,7 +268,7 @@ partitionLT_GT y h = (h', C.unionList hs)
                       (b', hs'') = collect b hs'
                   in (T x a' b', hs'')
 
-minView :: (Ord a, Monad m) => Heap a -> m (a, Heap a)
+minView :: (Ord a, MF.MonadFail m) => Heap a -> m (a, Heap a)
 minView E = fail "SkewHeap.minView: empty heap"
 minView (T x a b) = return (x, union a b)
 
@@ -275,7 +276,7 @@ minElem :: Ord a => Heap a -> a
 minElem E = error "SkewHeap.minElem: empty collection"
 minElem (T x _ _) = x
 
-maxView :: (Ord a, Monad m) => Heap a -> m (a, Heap a)
+maxView :: (Ord a, MF.MonadFail m) => Heap a -> m (a, Heap a)
 maxView E = fail "SkewHeap.maxView: empty heap"
 maxView (T x E E) = return (x, E)
 maxView (T x a E) = return (y, T x a' E)

--- a/edison-core/src/Data/Edison/Coll/SplayHeap.hs
+++ b/edison-core/src/Data/Edison/Coll/SplayHeap.hs
@@ -50,6 +50,7 @@ import Data.Edison.Coll.Defaults
 import Data.Monoid
 import Data.Semigroup as SG
 import Control.Monad
+import qualified Control.Monad.Fail as MF
 import Test.QuickCheck
 
 moduleName :: String
@@ -93,7 +94,7 @@ strict    :: Heap a -> Heap a
 
 toSeq     :: (Ord a, S.Sequence s) => Heap a -> s a
 lookup    :: Ord a => a -> Heap a -> a
-lookupM   :: (Ord a,Monad m) => a -> Heap a -> m a
+lookupM   :: (Ord a, MF.MonadFail m) => a -> Heap a -> m a
 lookupAll :: (Ord a,S.Sequence s) => a -> Heap a -> s a
 lookupWithDefault :: Ord a => a -> a -> Heap a -> a
 fold      :: Ord a => (a -> b -> b) -> b -> Heap a -> b
@@ -118,9 +119,9 @@ partitionLT_GE   :: Ord a => a -> Heap a -> (Heap a, Heap a)
 partitionLE_GT   :: Ord a => a -> Heap a -> (Heap a, Heap a)
 partitionLT_GT   :: Ord a => a -> Heap a -> (Heap a, Heap a)
 
-minView  :: (Ord a,Monad m) => Heap a -> m (a, Heap a)
+minView  :: (Ord a, MF.MonadFail m) => Heap a -> m (a, Heap a)
 minElem  :: Ord a => Heap a -> a
-maxView  :: (Ord a,Monad m) => Heap a -> m (a, Heap a)
+maxView  :: (Ord a, MF.MonadFail m) => Heap a -> m (a, Heap a)
 maxElem  :: Ord a => Heap a -> a
 foldr    :: Ord a => (a -> b -> b) -> b -> Heap a -> b
 foldl    :: Ord a => (b -> a -> b) -> b -> Heap a -> b

--- a/edison-core/src/Data/Edison/Coll/StandardSet.hs
+++ b/edison-core/src/Data/Edison/Coll/StandardSet.hs
@@ -43,6 +43,7 @@ module Data.Edison.Coll.StandardSet (
 
 import Prelude hiding (null,foldr,foldl,foldr1,foldl1,lookup,filter)
 import qualified Prelude
+import qualified Control.Monad.Fail as MF
 import qualified Data.List
 
 import qualified Data.Edison.Coll as C
@@ -73,7 +74,7 @@ strict     :: Ord a => Set a -> Set a
 
 toSeq      :: (Ord a,S.Sequence seq) => Set a -> seq a
 lookup     :: Ord a => a -> Set a -> a
-lookupM    :: (Ord a,Monad m) => a -> Set a -> m a
+lookupM    :: (Ord a, Monad m, MF.MonadFail m) => a -> Set a -> m a
 lookupAll  :: (Ord a,S.Sequence seq) => a -> Set a -> seq a
 lookupWithDefault :: Ord a => a -> a -> Set a  -> a
 fold       :: (a -> b -> b) -> b -> Set a -> b
@@ -98,9 +99,9 @@ partitionLT_GE   :: Ord a => a -> Set a -> (Set a, Set a)
 partitionLE_GT   :: Ord a => a -> Set a -> (Set a, Set a)
 partitionLT_GT   :: Ord a => a -> Set a -> (Set a, Set a)
 
-minView       :: (Ord a,Monad m) => Set a -> m (a, Set a)
+minView       :: (Ord a, Monad m, MF.MonadFail m) => Set a -> m (a, Set a)
 minElem       :: Set a -> a
-maxView       :: (Ord a,Monad m) => Set a -> m (a, Set a)
+maxView       :: (Ord a, Monad m, MF.MonadFail m) => Set a -> m (a, Set a)
 maxElem       :: Set a -> a
 foldr         :: (a -> b -> b) -> b -> Set a -> b
 foldl         :: (b -> a -> b) -> b -> Set a -> b

--- a/edison-core/src/Data/Edison/Coll/UnbalancedSet.hs
+++ b/edison-core/src/Data/Edison/Coll/UnbalancedSet.hs
@@ -43,6 +43,7 @@ module Data.Edison.Coll.UnbalancedSet (
 
 import Prelude hiding (null,foldr,foldl,foldr1,foldl1,lookup,filter)
 import qualified Prelude
+import qualified Control.Monad.Fail as MF
 import qualified Data.Edison.Coll as C
 import qualified Data.Edison.Seq as S
 import Data.Edison.Coll.Defaults
@@ -70,7 +71,7 @@ strict     :: Set a -> Set a
 
 toSeq      :: (Ord a,S.Sequence seq) => Set a -> seq a
 lookup     :: Ord a => a -> Set a -> a
-lookupM    :: (Ord a,Monad m) => a -> Set a -> m a
+lookupM    :: (Ord a, MF.MonadFail m) => a -> Set a -> m a
 lookupAll  :: (Ord a,S.Sequence seq) => a -> Set a -> seq a
 lookupWithDefault :: Ord a => a -> a -> Set a -> a
 fold       :: (a -> b -> b) -> b -> Set a -> b
@@ -95,9 +96,9 @@ partitionLT_GE   :: Ord a => a -> Set a -> (Set a, Set a)
 partitionLE_GT   :: Ord a => a -> Set a -> (Set a, Set a)
 partitionLT_GT   :: Ord a => a -> Set a -> (Set a, Set a)
 
-minView       :: (Monad m) => Set a -> m (a, Set a)
+minView       :: (MF.MonadFail m) => Set a -> m (a, Set a)
 minElem       :: Set a -> a
-maxView       :: (Monad m) => Set a -> m (a, Set a)
+maxView       :: (MF.MonadFail m) => Set a -> m (a, Set a)
 maxElem       :: Set a -> a
 foldr         :: (a -> b -> b) -> b -> Set a -> b
 foldl         :: (b -> a -> b) -> b -> Set a -> b

--- a/edison-core/src/Data/Edison/Concrete/FingerTree.hs
+++ b/edison-core/src/Data/Edison/Concrete/FingerTree.hs
@@ -81,6 +81,7 @@ import Test.QuickCheck
 import Data.Edison.Prelude
 
 import Control.Monad (liftM2, liftM3, liftM4)
+import qualified Control.Monad.Fail as MF
 
 
 infixr 5 `lcons`
@@ -334,7 +335,7 @@ null Empty = True
 null _ = False
 
 -- | /O(1)/. Analyse the left end of a sequence.
-lview :: (Measured v a, Monad m) => FingerTree v a -> m (a,FingerTree v a)
+lview :: (Measured v a, MF.MonadFail m) => FingerTree v a -> m (a,FingerTree v a)
 lview Empty                 =  fail "FingerTree.lview: empty tree"
 lview (Single x)            =  return (x, Empty)
 lview (Deep _ (One x) m sf) =  return . (,) x $
@@ -357,7 +358,7 @@ ltailDigit (Four _ b c d) = Three b c d
 ltailDigit _ = error "FingerTree.ltailDigit: bug!"
 
 -- | /O(1)/. Analyse the right end of a sequence.
-rview :: (Measured v a, Monad m) => FingerTree v a -> m (a, FingerTree v a)
+rview :: (Measured v a, MF.MonadFail m) => FingerTree v a -> m (a, FingerTree v a)
 rview Empty                  = fail "FingerTree.rview: empty tree"
 rview (Single x)             = return (x, Empty)
 rview (Deep _ pr m (One x))  = return . (,) x $

--- a/edison-core/src/Data/Edison/Seq/BankersQueue.hs
+++ b/edison-core/src/Data/Edison/Seq/BankersQueue.hs
@@ -56,6 +56,7 @@ import Data.Edison.Seq.Defaults
 import qualified Data.Edison.Seq.ListSeq as L
 import Data.Monoid
 import Data.Semigroup as SG
+import qualified Control.Monad.Fail as MF
 import Control.Monad.Identity
 import Test.QuickCheck
 
@@ -66,16 +67,16 @@ singleton      :: a -> Seq a
 lcons          :: a -> Seq a -> Seq a
 rcons          :: a -> Seq a -> Seq a
 append         :: Seq a -> Seq a -> Seq a
-lview          :: (Monad m) => Seq a -> m (a, Seq a)
+lview          :: (MF.MonadFail m) => Seq a -> m (a, Seq a)
 lhead          :: Seq a -> a
-lheadM         :: (Monad m) => Seq a -> m a
+lheadM         :: (MF.MonadFail m) => Seq a -> m a
 ltail          :: Seq a -> Seq a
-ltailM         :: (Monad m) => Seq a -> m (Seq a)
-rview          :: (Monad m) => Seq a -> m (a, Seq a)
+ltailM         :: (MF.MonadFail m) => Seq a -> m (Seq a)
+rview          :: (MF.MonadFail m) => Seq a -> m (a, Seq a)
 rhead          :: Seq a -> a
-rheadM         :: (Monad m) => Seq a -> m a
+rheadM         :: (MF.MonadFail m) => Seq a -> m a
 rtail          :: Seq a -> Seq a
-rtailM         :: (Monad m) => Seq a -> m (Seq a)
+rtailM         :: (MF.MonadFail m) => Seq a -> m (Seq a)
 null           :: Seq a -> Bool
 size           :: Seq a -> Int
 concat         :: Seq (Seq a) -> Seq a
@@ -106,7 +107,7 @@ reduce1'       :: (a -> a -> a) -> Seq a -> a
 copy           :: Int -> a -> Seq a
 inBounds       :: Int -> Seq a -> Bool
 lookup         :: Int -> Seq a -> a
-lookupM        :: (Monad m) => Int -> Seq a -> m a
+lookupM        :: (MF.MonadFail m) => Int -> Seq a -> m a
 lookupWithDefault :: a -> Int -> Seq a -> a
 update         :: Int -> a -> Seq a -> Seq a
 adjust         :: (a -> a) -> Int -> Seq a -> Seq a

--- a/edison-core/src/Data/Edison/Seq/BinaryRandList.hs
+++ b/edison-core/src/Data/Edison/Seq/BinaryRandList.hs
@@ -63,6 +63,7 @@ import Data.Edison.Seq.Defaults
 import Data.Monoid
 import Data.Semigroup as SG
 import Control.Monad
+import qualified Control.Monad.Fail as MF
 import Test.QuickCheck
 
 -- signatures for exported functions
@@ -72,16 +73,16 @@ singleton      :: a -> Seq a
 lcons          :: a -> Seq a -> Seq a
 rcons          :: a -> Seq a -> Seq a
 append         :: Seq a -> Seq a -> Seq a
-lview          :: (Monad m) => Seq a -> m (a, Seq a)
+lview          :: (MF.MonadFail m) => Seq a -> m (a, Seq a)
 lhead          :: Seq a -> a
-lheadM         :: (Monad m) => Seq a -> m a
+lheadM         :: (MF.MonadFail m) => Seq a -> m a
 ltail          :: Seq a -> Seq a
-ltailM         :: (Monad m) => Seq a -> m (Seq a)
-rview          :: (Monad m) => Seq a -> m (a, Seq a)
+ltailM         :: (MF.MonadFail m) => Seq a -> m (Seq a)
+rview          :: (MF.MonadFail m) => Seq a -> m (a, Seq a)
 rhead          :: Seq a -> a
-rheadM         :: (Monad m) => Seq a -> m a
+rheadM         :: (MF.MonadFail m) => Seq a -> m a
 rtail          :: Seq a -> Seq a
-rtailM         :: (Monad m) => Seq a -> m (Seq a)
+rtailM         :: (MF.MonadFail m) => Seq a -> m (Seq a)
 null           :: Seq a -> Bool
 size           :: Seq a -> Int
 concat         :: Seq (Seq a) -> Seq a
@@ -112,7 +113,7 @@ reduce1'       :: (a -> a -> a) -> Seq a -> a
 copy           :: Int -> a -> Seq a
 inBounds       :: Int -> Seq a -> Bool
 lookup         :: Int -> Seq a -> a
-lookupM        :: (Monad m) => Int -> Seq a -> m a
+lookupM        :: (MF.MonadFail m) => Int -> Seq a -> m a
 lookupWithDefault :: a -> Int -> Seq a -> a
 update         :: Int -> a -> Seq a -> Seq a
 adjust         :: (a -> a) -> Int -> Seq a -> Seq a

--- a/edison-core/src/Data/Edison/Seq/BraunSeq.hs
+++ b/edison-core/src/Data/Edison/Seq/BraunSeq.hs
@@ -72,6 +72,7 @@ import Prelude hiding (concat,reverse,map,concatMap,foldr,foldl,foldr1,foldl1,
                        zip,zip3,zipWith,zipWith3,unzip,unzip3,null)
 
 import qualified Control.Applicative as App
+import qualified Control.Monad.Fail as MF
 import Control.Monad.Identity
 import Data.Maybe
 import Data.Monoid
@@ -91,16 +92,16 @@ singleton      :: a -> Seq a
 lcons          :: a -> Seq a -> Seq a
 rcons          :: a -> Seq a -> Seq a
 append         :: Seq a -> Seq a -> Seq a
-lview          :: (Monad m) => Seq a -> m (a, Seq a)
+lview          :: (MF.MonadFail m) => Seq a -> m (a, Seq a)
 lhead          :: Seq a -> a
-lheadM         :: (Monad m) => Seq a -> m a
+lheadM         :: (MF.MonadFail m) => Seq a -> m a
 ltail          :: Seq a -> Seq a
-ltailM         :: (Monad m) => Seq a -> m (Seq a)
-rview          :: (Monad m) => Seq a -> m (a, Seq a)
+ltailM         :: (MF.MonadFail m) => Seq a -> m (Seq a)
+rview          :: (MF.MonadFail m) => Seq a -> m (a, Seq a)
 rhead          :: Seq a -> a
-rheadM         :: (Monad m) => Seq a -> m a
+rheadM         :: (MF.MonadFail m) => Seq a -> m a
 rtail          :: Seq a -> Seq a
-rtailM         :: (Monad m) => Seq a -> m (Seq a)
+rtailM         :: (MF.MonadFail m) => Seq a -> m (Seq a)
 null           :: Seq a -> Bool
 size           :: Seq a -> Int
 concat         :: Seq (Seq a) -> Seq a
@@ -131,7 +132,7 @@ reduce1'       :: (a -> a -> a) -> Seq a -> a
 copy           :: Int -> a -> Seq a
 inBounds       :: Int -> Seq a -> Bool
 lookup         :: Int -> Seq a -> a
-lookupM        :: (Monad m) => Int -> Seq a -> m a
+lookupM        :: (MF.MonadFail m) => Int -> Seq a -> m a
 lookupWithDefault :: a -> Int -> Seq a -> a
 update         :: Int -> a -> Seq a -> Seq a
 adjust         :: (a -> a) -> Int -> Seq a -> Seq a

--- a/edison-core/src/Data/Edison/Seq/Defaults.hs
+++ b/edison-core/src/Data/Edison/Seq/Defaults.hs
@@ -17,6 +17,7 @@ import Prelude hiding (concat,reverse,map,concatMap,foldr,foldl,foldr1,foldl1,
                        filter,takeWhile,dropWhile,lookup,take,drop,splitAt,
                        zip,zip3,zipWith,zipWith3,unzip,unzip3,null)
 
+import qualified Control.Monad.Fail as MF
 import Control.Monad.Identity
 import Data.Char (isSpace)
 
@@ -33,7 +34,7 @@ appendUsingFoldr :: Sequence s => s a -> s a -> s a
 appendUsingFoldr s t | null t = s
                             | otherwise = foldr lcons t s
 
-rviewDefault :: (Monad m, Sequence s) => s a -> m (a, s a)
+rviewDefault :: (MF.MonadFail m, Sequence s) => s a -> m (a, s a)
 rviewDefault xs
   | null xs   = fail $ instanceName xs ++ ".rview: empty sequence"
   | otherwise = return (rhead xs, rtail xs)
@@ -49,7 +50,7 @@ rtailUsingLview xs =
             Nothing      -> empty
             Just (y, ys) -> lcons x (rt y ys)
 
-rtailMUsingLview :: (Monad m,Sequence s) => s a -> m (s a)
+rtailMUsingLview :: (MF.MonadFail m, Sequence s) => s a -> m (s a)
 rtailMUsingLview xs =
     case lview xs of
       Nothing      -> fail $ instanceName xs ++ ".rtailM: empty sequence"
@@ -220,7 +221,7 @@ lookupWithDefaultUsingDrop d i s
   | otherwise = lhead s'
   where s' = drop i s
 
-lookupMUsingDrop :: (Monad m, Sequence s) => Int -> s a -> m a
+lookupMUsingDrop :: (MF.MonadFail m, Sequence s) => Int -> s a -> m a
 lookupMUsingDrop i s
   -- XXX better error message!
   | i < 0 || null s' = fail $ instanceName s

--- a/edison-core/src/Data/Edison/Seq/FingerSeq.hs
+++ b/edison-core/src/Data/Edison/Seq/FingerSeq.hs
@@ -40,6 +40,7 @@ import qualified Control.Applicative as App
 import Data.Edison.Prelude (measure, Measured())
 import qualified Data.Edison.Seq as S
 import Data.Edison.Seq.Defaults
+import qualified Control.Monad.Fail as MF
 import Control.Monad.Identity
 import Data.Monoid
 import Data.Semigroup as SG
@@ -87,16 +88,16 @@ singleton      :: a -> Seq a
 lcons          :: a -> Seq a -> Seq a
 rcons          :: a -> Seq a -> Seq a
 append         :: Seq a -> Seq a -> Seq a
-lview          :: (Monad m) => Seq a -> m (a, Seq a)
+lview          :: (MF.MonadFail m) => Seq a -> m (a, Seq a)
 lhead          :: Seq a -> a
-lheadM         :: (Monad m) => Seq a -> m a
+lheadM         :: (MF.MonadFail m) => Seq a -> m a
 ltail          :: Seq a -> Seq a
-ltailM         :: (Monad m) => Seq a -> m (Seq a)
-rview          :: (Monad m) => Seq a -> m (a, Seq a)
+ltailM         :: (MF.MonadFail m) => Seq a -> m (Seq a)
+rview          :: (MF.MonadFail m) => Seq a -> m (a, Seq a)
 rhead          :: Seq a -> a
-rheadM         :: (Monad m) => Seq a -> m a
+rheadM         :: (MF.MonadFail m) => Seq a -> m a
 rtail          :: Seq a -> Seq a
-rtailM         :: (Monad m) => Seq a -> m (Seq a)
+rtailM         :: (MF.MonadFail m) => Seq a -> m (Seq a)
 null           :: Seq a -> Bool
 size           :: Seq a -> Int
 concat         :: Seq (Seq a) -> Seq a
@@ -127,7 +128,7 @@ reduce1'       :: (a -> a -> a) -> Seq a -> a
 copy           :: Int -> a -> Seq a
 inBounds       :: Int -> Seq a -> Bool
 lookup         :: Int -> Seq a -> a
-lookupM        :: (Monad m) => Int -> Seq a -> m a
+lookupM        :: (MF.MonadFail m) => Int -> Seq a -> m a
 lookupWithDefault :: a -> Int -> Seq a -> a
 update         :: Int -> a -> Seq a -> Seq a
 adjust         :: (a -> a) -> Int -> Seq a -> Seq a

--- a/edison-core/src/Data/Edison/Seq/JoinList.hs
+++ b/edison-core/src/Data/Edison/Seq/JoinList.hs
@@ -57,6 +57,7 @@ import qualified Control.Applicative as App
 
 import Data.Edison.Seq.Defaults
 import Control.Monad
+import qualified Control.Monad.Fail as MF
 import Data.Monoid
 import Data.Semigroup as SG
 import Test.QuickCheck
@@ -68,16 +69,16 @@ singleton      :: a -> Seq a
 lcons          :: a -> Seq a -> Seq a
 rcons          :: a -> Seq a -> Seq a
 append         :: Seq a -> Seq a -> Seq a
-lview          :: (Monad m) => Seq a -> m (a, Seq a)
+lview          :: (MF.MonadFail m) => Seq a -> m (a, Seq a)
 lhead          :: Seq a -> a
-lheadM         :: (Monad m) => Seq a -> m a
+lheadM         :: (MF.MonadFail m) => Seq a -> m a
 ltail          :: Seq a -> Seq a
-ltailM         :: (Monad m) => Seq a -> m (Seq a)
-rview          :: (Monad m) => Seq a -> m (a, Seq a)
+ltailM         :: (MF.MonadFail m) => Seq a -> m (Seq a)
+rview          :: (MF.MonadFail m) => Seq a -> m (a, Seq a)
 rhead          :: Seq a -> a
-rheadM         :: (Monad m) => Seq a -> m a
+rheadM         :: (MF.MonadFail m) => Seq a -> m a
 rtail          :: Seq a -> Seq a
-rtailM         :: (Monad m) => Seq a -> m (Seq a)
+rtailM         :: (MF.MonadFail m) => Seq a -> m (Seq a)
 null           :: Seq a -> Bool
 size           :: Seq a -> Int
 concat         :: Seq (Seq a) -> Seq a
@@ -108,7 +109,7 @@ reduce1'       :: (a -> a -> a) -> Seq a -> a
 copy           :: Int -> a -> Seq a
 inBounds       :: Int -> Seq a -> Bool
 lookup         :: Int -> Seq a -> a
-lookupM        :: (Monad m) => Int -> Seq a -> m a
+lookupM        :: (MF.MonadFail m) => Int -> Seq a -> m a
 lookupWithDefault :: a -> Int -> Seq a -> a
 update         :: Int -> a -> Seq a -> Seq a
 adjust         :: (a -> a) -> Int -> Seq a -> Seq a

--- a/edison-core/src/Data/Edison/Seq/MyersStack.hs
+++ b/edison-core/src/Data/Edison/Seq/MyersStack.hs
@@ -51,6 +51,7 @@ import Prelude hiding (concat,reverse,map,concatMap,foldr,foldl,foldr1,foldl1,
 import qualified Control.Applicative as App
 import qualified Data.Edison.Seq as S ( Sequence(..) )
 import Data.Edison.Seq.Defaults
+import qualified Control.Monad.Fail as MF
 import Control.Monad.Identity
 import Data.Monoid
 import Data.Semigroup as SG
@@ -63,16 +64,16 @@ singleton      :: a -> Seq a
 lcons          :: a -> Seq a -> Seq a
 rcons          :: a -> Seq a -> Seq a
 append         :: Seq a -> Seq a -> Seq a
-lview          :: (Monad m) => Seq a -> m (a, Seq a)
+lview          :: (MF.MonadFail m) => Seq a -> m (a, Seq a)
 lhead          :: Seq a -> a
-lheadM         :: (Monad m) => Seq a -> m a
+lheadM         :: (MF.MonadFail m) => Seq a -> m a
 ltail          :: Seq a -> Seq a
-ltailM         :: (Monad m) => Seq a -> m (Seq a)
-rview          :: (Monad m) => Seq a -> m (a, Seq a)
+ltailM         :: (MF.MonadFail m) => Seq a -> m (Seq a)
+rview          :: (MF.MonadFail m) => Seq a -> m (a, Seq a)
 rhead          :: Seq a -> a
-rheadM         :: (Monad m) => Seq a -> m a
+rheadM         :: (MF.MonadFail m) => Seq a -> m a
 rtail          :: Seq a -> Seq a
-rtailM         :: (Monad m) => Seq a -> m (Seq a)
+rtailM         :: (MF.MonadFail m) => Seq a -> m (Seq a)
 null           :: Seq a -> Bool
 size           :: Seq a -> Int
 concat         :: Seq (Seq a) -> Seq a
@@ -103,7 +104,7 @@ reduce1'       :: (a -> a -> a) -> Seq a -> a
 copy           :: Int -> a -> Seq a
 inBounds       :: Int -> Seq a -> Bool
 lookup         :: Int -> Seq a -> a
-lookupM        :: (Monad m) => Int -> Seq a -> m a
+lookupM        :: (MF.MonadFail m) => Int -> Seq a -> m a
 lookupWithDefault :: a -> Int -> Seq a -> a
 update         :: Int -> a -> Seq a -> Seq a
 adjust         :: (a -> a) -> Int -> Seq a -> Seq a

--- a/edison-core/src/Data/Edison/Seq/RandList.hs
+++ b/edison-core/src/Data/Edison/Seq/RandList.hs
@@ -57,6 +57,7 @@ import qualified Control.Applicative as App
 
 import qualified Data.Edison.Seq as S( Sequence(..) )
 import Data.Edison.Seq.Defaults
+import qualified Control.Monad.Fail as MF
 import Control.Monad.Identity
 import Data.Monoid
 import Data.Semigroup as SG
@@ -69,16 +70,16 @@ singleton      :: a -> Seq a
 lcons          :: a -> Seq a -> Seq a
 rcons          :: a -> Seq a -> Seq a
 append         :: Seq a -> Seq a -> Seq a
-lview          :: (Monad m) => Seq a -> m (a, Seq a)
+lview          :: (MF.MonadFail m) => Seq a -> m (a, Seq a)
 lhead          :: Seq a -> a
-lheadM         :: (Monad m) => Seq a -> m a
+lheadM         :: (MF.MonadFail m) => Seq a -> m a
 ltail          :: Seq a -> Seq a
-ltailM         :: (Monad m) => Seq a -> m (Seq a)
-rview          :: (Monad m) => Seq a -> m (a, Seq a)
+ltailM         :: (MF.MonadFail m) => Seq a -> m (Seq a)
+rview          :: (MF.MonadFail m) => Seq a -> m (a, Seq a)
 rhead          :: Seq a -> a
-rheadM         :: (Monad m) => Seq a -> m a
+rheadM         :: (MF.MonadFail m) => Seq a -> m a
 rtail          :: Seq a -> Seq a
-rtailM         :: (Monad m) => Seq a -> m (Seq a)
+rtailM         :: (MF.MonadFail m) => Seq a -> m (Seq a)
 null           :: Seq a -> Bool
 size           :: Seq a -> Int
 concat         :: Seq (Seq a) -> Seq a
@@ -109,7 +110,7 @@ reduce1'       :: (a -> a -> a) -> Seq a -> a
 copy           :: Int -> a -> Seq a
 inBounds       :: Int -> Seq a -> Bool
 lookup         :: Int -> Seq a -> a
-lookupM        :: (Monad m) => Int -> Seq a -> m a
+lookupM        :: (MF.MonadFail m) => Int -> Seq a -> m a
 lookupWithDefault :: a -> Int -> Seq a -> a
 update         :: Int -> a -> Seq a -> Seq a
 adjust         :: (a -> a) -> Int -> Seq a -> Seq a

--- a/edison-core/src/Data/Edison/Seq/RevSeq.hs
+++ b/edison-core/src/Data/Edison/Seq/RevSeq.hs
@@ -62,6 +62,7 @@ import qualified Data.Edison.Seq as S
 import qualified Data.Edison.Seq.ListSeq as L
 import Data.Edison.Seq.Defaults -- only used by concatMap
 import Control.Monad
+import qualified Control.Monad.Fail as MF
 import Data.Monoid
 import Data.Semigroup as SG
 import Test.QuickCheck
@@ -75,16 +76,16 @@ singleton      :: S.Sequence s => a -> Rev s a
 lcons          :: S.Sequence s => a -> Rev s a -> Rev s a
 rcons          :: S.Sequence s => a -> Rev s a -> Rev s a
 append         :: S.Sequence s => Rev s a -> Rev s a -> Rev s a
-lview          :: (S.Sequence s, Monad m) => Rev s a -> m (a, Rev s a)
+lview          :: (S.Sequence s, MF.MonadFail m) => Rev s a -> m (a, Rev s a)
 lhead          :: S.Sequence s => Rev s a -> a
-lheadM         :: (S.Sequence s, Monad m) => Rev s a -> m a
+lheadM         :: (S.Sequence s, MF.MonadFail m) => Rev s a -> m a
 ltail          :: S.Sequence s => Rev s a -> Rev s a
-ltailM         :: (S.Sequence s, Monad m) => Rev s a -> m (Rev s a)
-rview          :: (S.Sequence s, Monad m) => Rev s a -> m (a, Rev s a)
+ltailM         :: (S.Sequence s, MF.MonadFail m) => Rev s a -> m (Rev s a)
+rview          :: (S.Sequence s, MF.MonadFail m) => Rev s a -> m (a, Rev s a)
 rhead          :: S.Sequence s => Rev s a -> a
-rheadM         :: (S.Sequence s, Monad m) => Rev s a -> m a
+rheadM         :: (S.Sequence s, MF.MonadFail m) => Rev s a -> m a
 rtail          :: S.Sequence s => Rev s a -> Rev s a
-rtailM         :: (S.Sequence s, Monad m) => Rev s a -> m (Rev s a)
+rtailM         :: (S.Sequence s, MF.MonadFail m) => Rev s a -> m (Rev s a)
 null           :: S.Sequence s => Rev s a -> Bool
 size           :: S.Sequence s => Rev s a -> Int
 concat         :: S.Sequence s => Rev s (Rev s a) -> Rev s a
@@ -115,7 +116,7 @@ reduce1'       :: S.Sequence s => (a -> a -> a) -> Rev s a -> a
 copy           :: S.Sequence s => Int -> a -> Rev s a
 inBounds       :: S.Sequence s => Int -> Rev s a -> Bool
 lookup         :: S.Sequence s => Int -> Rev s a -> a
-lookupM        :: (S.Sequence s, Monad m) => Int -> Rev s a -> m a
+lookupM        :: (S.Sequence s, MF.MonadFail m) => Int -> Rev s a -> m a
 lookupWithDefault :: S.Sequence s => a -> Int -> Rev s a -> a
 update         :: S.Sequence s => Int -> a -> Rev s a -> Rev s a
 adjust         :: S.Sequence s => (a -> a) -> Int -> Rev s a -> Rev s a

--- a/edison-core/src/Data/Edison/Seq/SimpleQueue.hs
+++ b/edison-core/src/Data/Edison/Seq/SimpleQueue.hs
@@ -59,6 +59,7 @@ import qualified Data.Edison.Seq.ListSeq as L
 import Data.Monoid
 import Data.Semigroup as SG
 import Control.Monad
+import qualified Control.Monad.Fail as MF
 import Test.QuickCheck
 
 -- signatures for exported functions
@@ -68,16 +69,16 @@ singleton      :: a -> Seq a
 lcons          :: a -> Seq a -> Seq a
 rcons          :: a -> Seq a -> Seq a
 append         :: Seq a -> Seq a -> Seq a
-lview          :: (Monad m) => Seq a -> m (a, Seq a)
+lview          :: (MF.MonadFail m) => Seq a -> m (a, Seq a)
 lhead          :: Seq a -> a
-lheadM         :: (Monad m) => Seq a -> m a
+lheadM         :: (MF.MonadFail m) => Seq a -> m a
 ltail          :: Seq a -> Seq a
-ltailM         :: (Monad m) => Seq a -> m (Seq a)
-rview          :: (Monad m) => Seq a -> m (a, Seq a)
+ltailM         :: (MF.MonadFail m) => Seq a -> m (Seq a)
+rview          :: (MF.MonadFail m) => Seq a -> m (a, Seq a)
 rhead          :: Seq a -> a
-rheadM         :: (Monad m) => Seq a -> m a
+rheadM         :: (MF.MonadFail m) => Seq a -> m a
 rtail          :: Seq a -> Seq a
-rtailM         :: (Monad m) => Seq a -> m (Seq a)
+rtailM         :: (MF.MonadFail m) => Seq a -> m (Seq a)
 null           :: Seq a -> Bool
 size           :: Seq a -> Int
 concat         :: Seq (Seq a) -> Seq a
@@ -108,7 +109,7 @@ reduce1'       :: (a -> a -> a) -> Seq a -> a
 copy           :: Int -> a -> Seq a
 inBounds       :: Int -> Seq a -> Bool
 lookup         :: Int -> Seq a -> a
-lookupM        :: (Monad m) => Int -> Seq a -> m a
+lookupM        :: (MF.MonadFail m) => Int -> Seq a -> m a
 lookupWithDefault :: a -> Int -> Seq a -> a
 update         :: Int -> a -> Seq a -> Seq a
 adjust         :: (a -> a) -> Int -> Seq a -> Seq a

--- a/edison-core/src/Data/Edison/Seq/SizedSeq.hs
+++ b/edison-core/src/Data/Edison/Seq/SizedSeq.hs
@@ -54,6 +54,7 @@ import Data.Edison.Seq.Defaults -- only used by concatMap
 import Data.Monoid
 import Data.Semigroup as SG
 import Control.Monad
+import qualified Control.Monad.Fail as MF
 import Test.QuickCheck
 
 
@@ -65,16 +66,16 @@ singleton      :: S.Sequence s => a -> Sized s a
 lcons          :: S.Sequence s => a -> Sized s a -> Sized s a
 rcons          :: S.Sequence s => a -> Sized s a -> Sized s a
 append         :: S.Sequence s => Sized s a -> Sized s a -> Sized s a
-lview          :: (S.Sequence s, Monad m) => Sized s a -> m (a, Sized s a)
+lview          :: (S.Sequence s, MF.MonadFail m) => Sized s a -> m (a, Sized s a)
 lhead          :: S.Sequence s => Sized s a -> a
-lheadM         :: (S.Sequence s, Monad m) => Sized s a -> m a
+lheadM         :: (S.Sequence s, MF.MonadFail m) => Sized s a -> m a
 ltail          :: S.Sequence s => Sized s a -> Sized s a
-ltailM         :: (S.Sequence s, Monad m) => Sized s a -> m (Sized s a)
-rview          :: (S.Sequence s, Monad m) => Sized s a -> m (a, Sized s a)
+ltailM         :: (S.Sequence s, MF.MonadFail m) => Sized s a -> m (Sized s a)
+rview          :: (S.Sequence s, MF.MonadFail m) => Sized s a -> m (a, Sized s a)
 rhead          :: S.Sequence s => Sized s a -> a
-rheadM         :: (S.Sequence s, Monad m) => Sized s a -> m a
+rheadM         :: (S.Sequence s, MF.MonadFail m) => Sized s a -> m a
 rtail          :: S.Sequence s => Sized s a -> Sized s a
-rtailM         :: (S.Sequence s, Monad m) => Sized s a -> m (Sized s a)
+rtailM         :: (S.Sequence s, MF.MonadFail m) => Sized s a -> m (Sized s a)
 null           :: S.Sequence s => Sized s a -> Bool
 size           :: S.Sequence s => Sized s a -> Int
 concat         :: S.Sequence s => Sized s (Sized s a) -> Sized s a
@@ -105,7 +106,7 @@ reduce1'       :: S.Sequence s => (a -> a -> a) -> Sized s a -> a
 copy           :: S.Sequence s => Int -> a -> Sized s a
 inBounds       :: S.Sequence s => Int -> Sized s a -> Bool
 lookup         :: S.Sequence s => Int -> Sized s a -> a
-lookupM        :: (S.Sequence s, Monad m) => Int -> Sized s a -> m a
+lookupM        :: (S.Sequence s, MF.MonadFail m) => Int -> Sized s a -> m a
 lookupWithDefault :: S.Sequence s => a -> Int -> Sized s a -> a
 update         :: S.Sequence s => Int -> a -> Sized s a -> Sized s a
 adjust         :: S.Sequence s => (a -> a) -> Int -> Sized s a -> Sized s a


### PR DESCRIPTION
GHC 8.8.1-alpha2 was [announced](https://mail.haskell.org/pipermail/ghc-devs/2019-June/017777.html). In this PR I fixed the compilation with this version of GHC. All changes were required by the MonadFail proposal (see [Library Changes](https://gitlab.haskell.org/ghc/ghc/wikis/migration/8.8#base-41300) in GHC 8.8.1).

Blocking https://github.com/agda/agda/issues/3725.