### PR TITLE
Fix compatibility with GHC 9.0

### DIFF
--- a/edison-core/src/Data/Edison/Seq/FingerSeq.hs
+++ b/edison-core/src/Data/Edison/Seq/FingerSeq.hs
@@ -46,7 +46,7 @@ import Data.Semigroup as SG
 import Test.QuickCheck
 
 #ifdef __GLASGOW_HASKELL__
-import GHC.Base (unsafeCoerce#)
+import GHC.Exts (unsafeCoerce#)
 #endif
 
 


### PR DESCRIPTION
The change is according to https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0#unsafecoerce and should be backwards-compatible.

This applies on top of #16 and fixes #17